### PR TITLE
fixes #15 - incorrect homepage URL in setup.py

### DIFF
--- a/configobj.py
+++ b/configobj.py
@@ -78,7 +78,7 @@ tdquot = "'''%s'''"
 # Sentinel for use in getattr calls to replace hasattr
 MISSING = object()
 
-__version__ = '5.0.0'
+__version__ = '5.0.1'
 
 try:
     any

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ MODULES = 'configobj', 'validate'
 
 DESCRIPTION = 'Config file reading, writing and validation.'
 
-URL = 'http://https://github.com/DiffSK/configobj'
+URL = 'https://github.com/DiffSK/configobj'
 
 LONG_DESCRIPTION = """**ConfigObj** is a simple but powerful config file reader and writer: an *ini
 file round tripper*. Its main feature is that it is very easy to use, with a


### PR DESCRIPTION
And it will make it to pypi.python.org and mess it up there.
This changeset includes bumping version number to 5.0.1 (though this should be considered a development version since we won't tag a 5.0.1 until we see issues reported with the code)
