### PR TITLE
fixes #26 - added check for python versions < 2.6 with error message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,13 @@
 
 # This software is licensed under the terms of the BSD license.
 # http://opensource.org/licenses/BSD-3-Clause
-
+import sys
 from distutils.core import setup
+
+if sys.version_info < (2, 6):
+    print('for python versions < 2.6 use configobj '
+          'version 4.7.2')
+    sys.exit(1)
 
 # TODO - #20 - refactor the way we do versions
 VERSION = '5.0.1'


### PR DESCRIPTION
in action

``` bash
$ python2.5 setup.py
for python versions < 2.6 use configobj version 4.7.2
$ echo $?
1
```
