### PR TITLE
Handle %-chars in invalid lines correctly

### DIFF
--- a/configobj.py
+++ b/configobj.py
@@ -1581,7 +1581,7 @@ class ConfigObj(Section):
                     self.indent_type = indent
                 cur_depth = sect_open.count('[')
                 if cur_depth != sect_close.count(']'):
-                    self._handle_error("Cannot compute the section depth at line %s.",
+                    self._handle_error("Cannot compute the section depth",
                                        NestingError, infile, cur_index)
                     continue
                 
@@ -1591,7 +1591,7 @@ class ConfigObj(Section):
                         parent = self._match_depth(this_section,
                                                    cur_depth).parent
                     except SyntaxError:
-                        self._handle_error("Cannot compute nesting level at line %s.",
+                        self._handle_error("Cannot compute nesting level",
                                            NestingError, infile, cur_index)
                         continue
                 elif cur_depth == this_section.depth:
@@ -1601,12 +1601,12 @@ class ConfigObj(Section):
                     # the new section is a child the current section
                     parent = this_section
                 else:
-                    self._handle_error("Section too nested at line %s.",
+                    self._handle_error("Section too nested",
                                        NestingError, infile, cur_index)
                     
                 sect_name = self._unquote(sect_name)
                 if sect_name in parent:
-                    self._handle_error('Duplicate section name at line %s.',
+                    self._handle_error('Duplicate section name',
                                        DuplicateError, infile, cur_index)
                     continue
                 
@@ -1626,7 +1626,7 @@ class ConfigObj(Section):
             mat = self._keyword.match(line)
             if mat is None:
                 self._handle_error(
-                    'Invalid line ({0!r}) (matched as neither section nor keyword) at line "%s".'.format(line),
+                    'Invalid line ({0!r}) (matched as neither section nor keyword)'.format(line),
                     ParseError, infile, cur_index)
             else:
                 # is a keyword value
@@ -1641,7 +1641,7 @@ class ConfigObj(Section):
                             value, infile, cur_index, maxline)
                     except SyntaxError:
                         self._handle_error(
-                            'Parse error in multiline value at line %s.',
+                            'Parse error in multiline value',
                             ParseError, infile, cur_index)
                         continue
                     else:
@@ -1651,9 +1651,9 @@ class ConfigObj(Section):
                                 value = unrepr(value)
                             except Exception as e:
                                 if type(e) == UnknownType:
-                                    msg = 'Unknown name or type in value at line %s.'
+                                    msg = 'Unknown name or type in value'
                                 else:
-                                    msg = 'Parse error from unrepr-ing multiline value at line %s.'
+                                    msg = 'Parse error from unrepr-ing multiline value'
                                 self._handle_error(msg, UnreprError, infile,
                                     cur_index)
                                 continue
@@ -1664,9 +1664,9 @@ class ConfigObj(Section):
                             value = unrepr(value)
                         except Exception as e:
                             if isinstance(e, UnknownType):
-                                msg = 'Unknown name or type in value at line %s.'
+                                msg = 'Unknown name or type in value'
                             else:
-                                msg = 'Parse error from unrepr-ing value at line %s.'
+                                msg = 'Parse error from unrepr-ing value'
                             self._handle_error(msg, UnreprError, infile,
                                 cur_index)
                             continue
@@ -1676,14 +1676,14 @@ class ConfigObj(Section):
                             (value, comment) = self._handle_value(value)
                         except SyntaxError:
                             self._handle_error(
-                                'Parse error in value at line %s.',
+                                'Parse error in value',
                                 ParseError, infile, cur_index)
                             continue
                 #
                 key = self._unquote(key)
                 if key in this_section:
                     self._handle_error(
-                        'Duplicate keyword name at line %s.',
+                        'Duplicate keyword name',
                         DuplicateError, infile, cur_index)
                     continue
                 # add the key.
@@ -1734,7 +1734,7 @@ class ConfigObj(Section):
         """
         line = infile[cur_index]
         cur_index += 1
-        message = text % cur_index
+        message = '{0} at line {1}.'.format(text, cur_index)
         error = ErrorClass(message, cur_index, line)
         if self.raise_errors:
             # raise the error - parsing stops here

--- a/tests/test_validate_errors.py
+++ b/tests/test_validate_errors.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from configobj import ConfigObj, get_extra_values
+from configobj import ConfigObj, get_extra_values, ParseError
 from validate import Validator
 
 @pytest.fixture()
@@ -63,3 +63,10 @@ def test_get_extra_values(conf):
         (('section',), 'extra-sub-section'),
     ])
     assert sorted(extra_values) == expected
+
+
+def test_invalid_lines_with_percents(tmpdir, specpath):
+    ini = tmpdir.join('config.ini')
+    ini.write('extra: %H:%M\n')
+    with pytest.raises(ParseError):
+        conf = ConfigObj(str(ini), configspec=specpath, file_error=True)


### PR DESCRIPTION
The use of string formatting for inserting the line number doesn't work well
if the line itself contains percents. This patch avoids the use of directly
formatting the text, and also cleans up some inconsistencies
(`at line "%s"` vs `at line %s`).
