### PR TITLE
replace isinstance(...,dict) checks with Mapping

### DIFF
--- a/configobj.py
+++ b/configobj.py
@@ -16,6 +16,7 @@
 import os
 import re
 import sys
+import collections
 
 from codecs import BOM_UTF8, BOM_UTF16, BOM_UTF16_BE, BOM_UTF16_LE
 
@@ -595,7 +596,7 @@ class Section(dict):
             if key not in self:
                 self.sections.append(key)
             dict.__setitem__(self, key, value)
-        elif isinstance(value, dict) and not unrepr:
+        elif isinstance(value, collections.Mapping) and not unrepr:
             # First create the new depth level,
             # then create the section
             if key not in self:
@@ -802,8 +803,8 @@ class Section(dict):
         ConfigObj({'section1': {'option1': 'False', 'subsection': {'more_options': 'False'}}})
         """
         for key, val in list(indict.items()):
-            if (key in self and isinstance(self[key], dict) and
-                                isinstance(val, dict)):
+            if (key in self and isinstance(self[key], collections.Mapping) and
+                                isinstance(val, collections.Mapping)):
                 self[key].merge(val)
             else:   
                 self[key] = val
@@ -2440,7 +2441,7 @@ def flatten_errors(cfg, res, levels=None, results=None):
     for (key, val) in list(res.items()):
         if val == True:
             continue
-        if isinstance(cfg.get(key), dict):
+        if isinstance(cfg.get(key), collections.Mapping):
             # Go down one level
             levels.append(key)
             flatten_errors(cfg[key], val, levels, results)


### PR DESCRIPTION
Okay here is the replacement of `dict` checks, as discussed in #76. Because I still don't know the insides for ConfigObj all too well, I hope it doesn't break anything as long as the tests run through.
