### PR TITLE
Added on_change parameter to ConfigObj and Section to have data change trigger a callback

### DIFF
--- a/configobj.py
+++ b/configobj.py
@@ -6,6 +6,7 @@
 # Nicola Larosa: nico AT tekNico DOT net
 # Rob Dennis: rdennis AT gmail DOT com
 # Eli Courtwright: eli AT courtwright DOT org
+# Kris Hardy: kris AT rkrishardy DOT com (Added on_change callback for event triggering)
 
 # This software is licensed under the terms of the BSD license.
 # http://opensource.org/licenses/BSD-3-Clause
@@ -484,12 +485,13 @@ class Section(dict):
         return (__newobj__, (self.__class__,), state)
     
     
-    def __init__(self, parent, depth, main, indict=None, name=None):
+    def __init__(self, parent, depth, main, indict=None, name=None, on_change=None):
         """
         * parent is the section above
         * depth is the depth level of this section
         * main is the main ConfigObj
         * indict is a dictionary to initialise the section with
+        * on_change is a callable to execute when a change occurs in the data
         """
         if indict is None:
             indict = {}
@@ -502,6 +504,8 @@ class Section(dict):
         self.depth = depth
         # purely for information
         self.name = name
+        # callable to execute when a change occurs
+        self.on_change = on_change
         #
         self._initialise()
         # we do this explicitly so that __setitem__ is used properly
@@ -592,6 +596,7 @@ class Section(dict):
         if key in self.defaults:
             self.defaults.remove(key)
         #
+        old_value = self[key] if key in self else None
         if isinstance(value, Section):
             if key not in self:
                 self.sections.append(key)
@@ -610,7 +615,8 @@ class Section(dict):
                     new_depth,
                     self.main,
                     indict=value,
-                    name=key))
+                    name=key,
+                    on_change=self.on_change))
         else:
             if key not in self:
                 self.scalars.append(key)
@@ -624,6 +630,8 @@ class Section(dict):
                 else:
                     raise TypeError('Value is not a string "%s".' % value)
             dict.__setitem__(self, key, value)
+        if old_value != value and callable(self.on_change):  # TODO: Is this really the right place to put this?
+            self.on_change(key, old_value, value)
 
 
     def __delitem__(self, key):
@@ -1176,7 +1184,7 @@ class ConfigObj(Section):
                  interpolation=True, raise_errors=False, list_values=True,
                  create_empty=False, file_error=False, stringify=True,
                  indent_type=None, default_encoding=None, unrepr=False,
-                 write_empty_values=False, _inspec=False):
+                 write_empty_values=False, _inspec=False, on_change=None):
         """
         Parse a config file or create a config file object.
         
@@ -1188,7 +1196,7 @@ class ConfigObj(Section):
         """
         self._inspec = _inspec
         # init the superclass
-        Section.__init__(self, self, 0, self)
+        Section.__init__(self, self, 0, self, on_change=on_change)
         
         infile = infile or []
         
@@ -1617,7 +1625,8 @@ class ConfigObj(Section):
                     parent,
                     cur_depth,
                     self,
-                    name=sect_name)
+                    name=sect_name,
+                    on_change=self.on_change)
                 parent[sect_name] = this_section
                 parent.inline_comments[sect_name] = comment
                 parent.comments[sect_name] = comment_list

--- a/configobj.py
+++ b/configobj.py
@@ -631,7 +631,7 @@ class Section(dict):
                     raise TypeError('Value is not a string "%s".' % value)
             dict.__setitem__(self, key, value)
         if old_value != value and callable(self.on_change):  # TODO: Is this really the right place to put this?
-            self.on_change(key, old_value, value)
+            self.on_change(self.name, key, old_value, value)
 
 
     def __delitem__(self, key):
@@ -1192,7 +1192,7 @@ class ConfigObj(Section):
                     interpolation=True, raise_errors=False, list_values=True,
                     create_empty=False, file_error=False, stringify=True,
                     indent_type=None, default_encoding=None, unrepr=False,
-                    write_empty_values=False, _inspec=False)``
+                    write_empty_values=False, _inspec=False, on_change=None)``
         """
         self._inspec = _inspec
         # init the superclass

--- a/docs/configobj.rst
+++ b/docs/configobj.rst
@@ -456,10 +456,13 @@ ConfigObj takes the following arguments (with the default values shown) :
 
     my_handler(name, key, old_value, value)
 
-    ``name`` will be the name of the section that changed (from Section.name)
-    ``key`` will be the key that changed
-    ``old_value`` will the be original value that was in the key
-    ``value`` will be the new value of the key
+    * ``name`` will be the name of the section that changed (from Section.name)
+
+    * ``key`` will be the key that changed
+
+    * ``old_value`` will the be original value that was in the key
+    
+    * ``value`` will be the new value of the key
 
     To detect the value change, an equality test is used (ie. old_value != value).
 

--- a/docs/configobj.rst
+++ b/docs/configobj.rst
@@ -461,7 +461,7 @@ ConfigObj takes the following arguments (with the default values shown) :
     * ``key`` will be the key that changed
 
     * ``old_value`` will the be original value that was in the key
-    
+
     * ``value`` will be the new value of the key
 
     To detect the value change, an equality test is used (ie. old_value != value).

--- a/tests/test_configobj.py
+++ b/tests/test_configobj.py
@@ -1298,3 +1298,52 @@ class TestEdgeCasesWhenWritingOut(object):
         c = ConfigObj(cfg, unrepr=True)
         assert repr(c) == "ConfigObj({'thing': {'a': 1}})"
         assert c.write() == ["thing = {'a': 1}"]
+
+
+class TestOnChange(object):
+    on_change_called = False
+    expected_name = None
+    expected_key = None
+    expected_old_value = None
+    expected_value = None
+
+    def on_change_handler(self, name, key, old_value, value):
+        self.on_change_called = True
+        assert name == self.expected_name
+        assert key == self.expected_key
+        assert old_value == self.expected_old_value
+        assert value == self.expected_value
+
+    def test_on_change(self):
+        c = ConfigObj(on_change=self.on_change_handler)
+
+        self.on_change_called = False
+        self.expected_name = None
+        self.expected_key = "test_section"
+        self.expected_old_value = None
+        self.expected_value = {}
+        c["test_section"] = {}
+        assert self.on_change_called is True
+
+        self.on_change_called = False
+        self.expected_name = "test_section"
+        self.expected_key = "test_value"
+        self.expected_old_value = None
+        self.expected_value = 1
+        c["test_section"]["test_value"] = 1
+        assert self.on_change_called is True
+
+        self.on_change_called = False
+        self.expected_name = "test_section"
+        self.expected_key = "test_value"
+        self.expected_old_value = 1
+        self.expected_value = 2
+        c["test_section"]["test_value"] = 2
+        assert self.on_change_called is True
+
+    def test_on_change_none(self):
+        c = ConfigObj(on_change=None)
+
+        self.on_change_called = False
+        c["test_section"] = {}
+        assert self.on_change_called == False


### PR DESCRIPTION
For your consideration...

If ConfigObj is instantiated with the ``on_change`` parameter set to a callable,
``on_change`` is called when changed data is detected in the root Section or any
subsection.  This is helpful for those cases where you may want a configuration
change to trigger some other action.

Here is an example of how to use ``on_change``:
```python
>>> def my_on_change_handler(name, key, old_value, value):
>>>     print("Detected change in [{0}]:{1} from {2} to {3}".format(name, key, old_value, value)
>>> my_configobj = ConfigObj(on_change=my_on_change_handler)
>>> my_configobj["section"] = {}
Detected change in [section]:None from None to {}
>>> my_configobj["section"]["parameter"] = 1
Detected change in [section]:parameter from None to 1
```

*** I looked at the tests but couldn't get them to run, and I'm not sure which files are acutally used for the tests.  Because of this, I didn't add in a test for on_change.  If you could point me in the right direction, I'd happily write the tests as well.

Thanks!
-Kris