### PR TITLE
Fix decoding for python 2 file data.

### DIFF
--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -1506,6 +1506,8 @@ class ConfigObj(Section):
         if is a string, it also needs converting to a list.
         """
         if isinstance(infile, six.string_types):
+            if six.PY2 and encoding is not None:
+                return infile.decode(encoding).splitlines(True)
             return infile.splitlines(True)
         if isinstance(infile, six.binary_type):
             # NOTE: Could raise a ``UnicodeDecodeError``


### PR DESCRIPTION
This fixes a problem for us after updating to configobj 5.0.6 from 4.7.2.  StringIOs with UTF-8 encoded data were not decoded with encoding=utf-8.

I don't know how to run the tests, so I couldn't add one.  I am somewhat doubtful about side-effects of this patch, but again, I can't run the tests, so I don't know.  The code is incomprehensible to me :) See #18 , which seems related.
