### PR TITLE
Colon used as separator #83

### DIFF
--- a/docs/configobj.rst
+++ b/docs/configobj.rst
@@ -444,6 +444,13 @@ ConfigObj takes the following arguments (with the default values shown) :
     creating a ConfigObj instance from a configspec file you must pass True
     for this argument as well as ``list_values=False``.
 
+* 'dividers': ``'='``
+
+    A string of character to use as dividers. It defaults to the equal sign
+    (`=`). For compatibility with `ConfigParser`, you can set it to
+    `diverders='=:'`. All characters not in `string.printable` will be
+    silently ignored.  Setting it to something strange is not advisable.
+
 
 Methods
 -------

--- a/docs/configobj.rst
+++ b/docs/configobj.rst
@@ -447,9 +447,17 @@ ConfigObj takes the following arguments (with the default values shown) :
 * 'dividers': ``'='``
 
     A string of character to use as dividers. It defaults to the equal sign
-    (`=`). For compatibility with `ConfigParser`, you can set it to
-    `diverders='=:'`. All characters not in `string.printable` will be
-    silently ignored.  Setting it to something strange is not advisable.
+    (`=`).  All characters not in `string.printable` will be silently ignored
+    and if no valid characters are found, an `AttributeError` will be raised.
+    
+    If multiple dividers are present on the same line, the *first one on that
+    line* will be taken as canon. Thus::
+
+        `Alice == in Wonderland` will become `'= in Wonderland'`.
+    
+    For compatibility with `ConfigParser`, you can set `dividers='=:'`. 
+
+    Setting it to something strange is not advisable.
 
 
 Methods

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ formats = zip
 universal = 1
 
 
-[pytest]
+[tool:pytest]
 norecursedirs = .* *.egg *.egg-info bin dist include lib local share static docs
 python_files = src/tests/test_*.py
 #addopts =

--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -22,6 +22,7 @@ import re
 import sys
 import copy
 import collections
+import string
 
 from codecs import BOM_UTF8, BOM_UTF16, BOM_UTF16_BE, BOM_UTF16_LE
 
@@ -1140,7 +1141,7 @@ class ConfigObj(Section):
                  interpolation=True, raise_errors=False, list_values=True,
                  create_empty=False, file_error=False, stringify=True,
                  indent_type=None, default_encoding=None, unrepr=False,
-                 write_empty_values=False, _inspec=False, dividers=None):
+                 write_empty_values=False, _inspec=False, dividers='='):
         """
         Parse a config file or create a config file object.
 
@@ -1148,13 +1149,15 @@ class ConfigObj(Section):
                     interpolation=True, raise_errors=False, list_values=True,
                     create_empty=False, file_error=False, stringify=True,
                     indent_type=None, default_encoding=None, unrepr=False,
-                    write_empty_values=False, _inspec=False)``
+                    write_empty_values=False, _inspec=False, dividers='=')``
         """
 
         # Dividers, see issue #83.
-        self._dividers = ['=', ]  # Defaults to equal (=) sign.
-        if dividers is not None:
-            self._dividers = dividers  # Custom values.
+        self._dividers = [x for x in dividers if x in string.printable]
+        if not self._dividers:
+            raise AttributeError("No valide characters found for dividers.")
+
+        # Inspect.
         self._inspec = _inspec
 
         # init the superclass

--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -23,7 +23,6 @@ import sys
 import copy
 import collections
 import string
-from copy import copy
 
 from codecs import BOM_UTF8, BOM_UTF16, BOM_UTF16_BE, BOM_UTF16_LE
 
@@ -758,7 +757,7 @@ class Section(dict):
         """
         for key, val in list(indict.items()):
             if decoupled:
-                val = copy(val)
+                val = copy.deepcopy(val)
             if (key in self and isinstance(self[key], collections.Mapping) and
                                 isinstance(val, collections.Mapping)):
                 self[key].merge(val, decoupled=decoupled)
@@ -1038,20 +1037,21 @@ class ConfigObj(Section):
 
     @property
     def _keyword(self):
-        if self.__keyword is None:
-            self.__keyword = re.compile(r'''^ # line start
-                (\s*)                   # indentation
-                (                       # keyword
-                    (?:".*?")|          # double quotes
-                    (?:'.*?')|          # single quotes
-                    (?:[^'"{0}].*?)     # no quotes
-                )
-                \s*[{0}]\s*             # dividers
-                (.*)                    # value (including list values and comments)
-                $   # line end
-                '''.format(''.join(self._dividers)),
-                re.VERBOSE)
-        return self.__keyword
+        #if self.__keyword is None:
+        #    self.__keyword = re.compile(r'''^ # line start
+        return re.compile(r'''^ # line start
+            (\s*)                   # indentation
+            (                       # keyword
+                (?:".*?")|          # double quotes
+                (?:'.*?')|          # single quotes
+                (?:[^'"{0}].*?)     # no quotes
+            )
+            \s*[{0}]\s*             # dividers
+            (.*)                    # value (including list values and comments)
+            $   # line end
+            '''.format(''.join(self._dividers)),
+            re.VERBOSE)
+        #return self.__keyword
 
     _sectionmarker = re.compile(r'''^
         (\s*)                     # 1: indentation

--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -23,6 +23,7 @@ import sys
 import copy
 import collections
 import string
+from copy import copy
 
 from codecs import BOM_UTF8, BOM_UTF16, BOM_UTF16_BE, BOM_UTF16_LE
 
@@ -757,7 +758,7 @@ class Section(dict):
         """
         for key, val in list(indict.items()):
             if decoupled:
-                val = copy.deepcopy(val)
+                val = copy(val)
             if (key in self and isinstance(self[key], collections.Mapping) and
                                 isinstance(val, collections.Mapping)):
                 self[key].merge(val, decoupled=decoupled)
@@ -1037,21 +1038,20 @@ class ConfigObj(Section):
 
     @property
     def _keyword(self):
-        #if self.__keyword is None:
-        #    self.__keyword = re.compile(r'''^ # line start
-        return re.compile(r'''^ # line start
-            (\s*)                   # indentation
-            (                       # keyword
-                (?:".*?")|          # double quotes
-                (?:'.*?')|          # single quotes
-                (?:[^'"{0}].*?)     # no quotes
-            )
-            \s*[{0}]\s*             # dividers
-            (.*)                    # value (including list values and comments)
-            $   # line end
-            '''.format(''.join(self._dividers)),
-            re.VERBOSE)
-        #return self.__keyword
+        if self.__keyword is None:
+            self.__keyword = re.compile(r'''^ # line start
+                (\s*)                   # indentation
+                (                       # keyword
+                    (?:".*?")|          # double quotes
+                    (?:'.*?')|          # single quotes
+                    (?:[^'"{0}].*?)     # no quotes
+                )
+                \s*[{0}]\s*             # dividers
+                (.*)                    # value (including list values and comments)
+                $   # line end
+                '''.format(''.join(self._dividers)),
+                re.VERBOSE)
+        return self.__keyword
 
     _sectionmarker = re.compile(r'''^
         (\s*)                     # 1: indentation

--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -1033,9 +1033,12 @@ class ConfigObj(Section):
     # TODO: also support inline comments (needs dynamic compiling of the regex below)
     COMMENT_MARKERS = ['#']
 
+    __keyword = None
 
     @property
     def _keyword(self):
+        #if self.__keyword is None:
+        #    self.__keyword = re.compile(r'''^ # line start
         return re.compile(r'''^ # line start
             (\s*)                   # indentation
             (                       # keyword
@@ -1048,6 +1051,7 @@ class ConfigObj(Section):
             $   # line end
             '''.format(''.join(self._dividers)),
             re.VERBOSE)
+        #return self.__keyword
 
     _sectionmarker = re.compile(r'''^
         (\s*)                     # 1: indentation
@@ -1155,7 +1159,7 @@ class ConfigObj(Section):
         # Dividers, see issue #83.
         self._dividers = [x for x in dividers if x in string.printable]
         if not self._dividers:
-            raise AttributeError("No valide characters found for dividers.")
+            raise AttributeError("No valid characters found for dividers.")
 
         # Inspect.
         self._inspec = _inspec

--- a/src/tests/test_configobj.py
+++ b/src/tests/test_configobj.py
@@ -1375,3 +1375,11 @@ class TestEdgeCasesWhenWritingOut(object):
         c = ConfigObj(cfg, unrepr=True)
         assert repr(c) == "ConfigObj({'thing': {'a': 1}})"
         assert c.write() == ["thing = {'a': 1}"]
+
+
+def test_curlon_instead_of_equal(cfg_contents):
+    cfg = cfg_contents("""
+[section]
+    ook : 'eek'
+    """)
+    c = ConfigObj(cfg, dividers=[':'])

--- a/src/tests/test_configobj.py
+++ b/src/tests/test_configobj.py
@@ -1377,9 +1377,26 @@ class TestEdgeCasesWhenWritingOut(object):
         assert c.write() == ["thing = {'a': 1}"]
 
 
-def test_curlon_instead_of_equal(cfg_contents):
+def test_dividers_happy(cfg_contents):
     cfg = cfg_contents("""
 [section]
     ook : 'eek'
+    monkey = True
+    beast + 666
     """)
-    c = ConfigObj(cfg, dividers=[':'])
+    c = ConfigObj(cfg, dividers=':=+')
+    assert c['section'] is not None
+    assert c['section']['ook'] == 'eek'
+    assert c['section']['monkey'] == 'True'
+    assert c['section']['beast'] == '666'
+
+
+def test_dividers_unhappy(cfg_contents):
+    cfg = cfg_contents(u"""
+[section]
+    ook … 'eek'
+    """)
+    try:
+        c = ConfigObj(cfg, dividers=u'…')
+    except AttributeError as err:
+        assert str(err) == "No valide characters found for dividers."

--- a/src/tests/test_configobj.py
+++ b/src/tests/test_configobj.py
@@ -1390,6 +1390,20 @@ def test_dividers_happy(cfg_contents):
     assert c['section']['monkey'] == 'True'
     assert c['section']['beast'] == '666'
 
+def test_dividers_many(cfg_contents):
+    cfg = cfg_contents("""
+[section]
+    ook =: 'eek'
+    monkey := True
+    Fred := some weird string
+    Alice == in Wonderland
+    """)
+    c = ConfigObj(cfg, dividers=':=')
+    assert c['section'] is not None
+    assert c['section']['ook'] == ": 'eek'"
+    assert c['section']['monkey'] == '= True'
+    assert c['section']['Fred'] == '= some weird string'
+    assert c['section']['Alice'] == '= in Wonderland'
 
 def test_dividers_unhappy(cfg_contents):
     cfg = cfg_contents(u"""
@@ -1399,4 +1413,4 @@ def test_dividers_unhappy(cfg_contents):
     try:
         c = ConfigObj(cfg, dividers=u'…')
     except AttributeError as err:
-        assert str(err) == "No valide characters found for dividers."
+        assert str(err) == "No valid characters found for dividers."


### PR DESCRIPTION
There is a new option called "`dividers`" that is a string of characters that could be use as separators as long as they are in the `string.printable` set.

There are two unit tests to make sure the functionality works. However, they are not exhaustive.

I think that the worst thing a user can do is pass some really weird characters in the above set that will cause the regex to return broken results. In that case, the parsing of the configuration file might fail or garbage could be loaded.

_Someone more versed in the code base and regex might want to have a look at the code!_
