### PR TITLE
fix autoenv zsh support

### DIFF
--- a/.env
+++ b/.env
@@ -26,11 +26,15 @@ case "$(uname -s)" in
 esac
 
 test -z "$JENKINS_URL" || echo '***' "\$0=$0" "\$BASH_SOURCE=${BASH_SOURCE[0]}"
-if test "$0" = "-bash" -o "$(basename -- "$0")" = "bash" -o "$(basename -- "${BASH_SOURCE[0]}")" = ".env"; then
+if test "$0" = "-bash" \
+    -o "$(basename -- "$0")" = "bash" \
+    -o "$(basename -- "${BASH_SOURCE[0]}")" = ".env"; then
     _venv_script=$($_venv_readlink -f ${BASH_SOURCE[0]})
-else
-    _venv_script="/dont-know-really/.env"
+elif test "$(basename -- "$0")" = ".env"; then
+    _venv_script=$($_venv_readlink -f "$0")
 fi
+_venv_script=${_venv_script:-/dont-know-really/.env}
+
 _venv_xtrace=$(set +o | grep xtrace)
 set +x
 _venv_name="$(basename $(pwd))"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ call these commands:
 ```sh
 git clone "https://github.com/DiffSK/configobj.git"
 cd "configobj"
-. .env --yes --develop
+source .env --yes --develop
 invoke build --docs test doctest check
 ```
 


### PR DESCRIPTION
While the autoenv repository referenced in the header supports alternate
shells, the version here is using numerous bash specific features. This
commit adds an alternate method for finding the current script path that
does not rely on $BATH_SOURCE, and supports the zsh shell.
