### PR TITLE
Strict spec validation

### DIFF
--- a/docs/configobj.rst
+++ b/docs/configobj.rst
@@ -522,7 +522,7 @@ validate
 
 .. code-block:: python
 
-    validate(validator, preserve_errors=False, copy=False)
+    validate(validator, preserve_errors=False, copy=False, strict_spec=False)
 
 .. code-block:: python
 

--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -2146,7 +2146,8 @@ class ConfigObj(Section):
             if preserve_errors:
                 # We do this once to remove a top level dependency on the validate module
                 # Which makes importing configobj faster
-                from configobj.validate import VdtMissingValue
+                from configobj.validate import VdtMissingDefinition, VdtMissingValue
+                self._vdtMissingDefinition = VdtMissingDefinition
                 self._vdtMissingValue = VdtMissingValue
 
             section = self
@@ -2277,7 +2278,7 @@ class ConfigObj(Section):
                 else:
                     ret_false = False
                     msg = 'Value %r was unrecognized' % entry
-                    out[entry] = validator.baseErrorClass(msg)
+                    out[entry] = self._vdtMissingDefinition(msg)
 
 
         # Missing sections will have been created as empty ones when the

--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -2098,7 +2098,7 @@ class ConfigObj(Section):
                 h.write(output_bytes)
 
     def validate(self, validator, preserve_errors=False, copy=False,
-                 section=None):
+                 section=None, strict_spec=False):
         """
         Test the ConfigObj against a configspec.
 
@@ -2128,6 +2128,13 @@ class ConfigObj(Section):
         still be marked as ``False``.
 
         You must have the validate module to use ``preserve_errors=True``.
+
+        If ``strict_spec`` is ``True`` (``False`` is default) then instead of
+        ignoring entries undefined by the configspec, unrecognized entries will
+        fail validation and be inserted into the return dictionary with an
+        informational ``ValidateError``.
+
+        You must have the validate module to use ``strict_spec=True``.
 
         You can then use the ``flatten_errors`` function to turn your nested
         results dictionary into a flattened list of failures - useful for
@@ -2263,6 +2270,15 @@ class ConfigObj(Section):
                 ret_false = False
                 msg = 'Section %r was provided as a single value' % entry
                 out[entry] = validator.baseErrorClass(msg)
+        if strict_spec:
+            for entry in unvalidated:
+                if not preserve_errors:
+                    out[entry] = False
+                else:
+                    ret_false = False
+                    msg = 'Value %r was unrecognized' % entry
+                    out[entry] = validator.baseErrorClass(msg)
+
 
         # Missing sections will have been created as empty ones when the
         # configspec was read.

--- a/src/configobj/validate.py
+++ b/src/configobj/validate.py
@@ -147,6 +147,7 @@ __all__ = (
     'VdtValueTooBigError',
     'VdtValueTooShortError',
     'VdtValueTooLongError',
+    'VdtMissingDefinition',
     'VdtMissingValue',
     'Validator',
     'is_integer',
@@ -366,6 +367,10 @@ class ValidateError(Exception):
     Traceback (most recent call last):
     ValidateError
     """
+
+
+class VdtMissingDefinition(ValidateError):
+    """A check was requested on an undefined entry"""
 
 
 class VdtMissingValue(ValidateError):

--- a/src/tests/test_validate_errors.py
+++ b/src/tests/test_validate_errors.py
@@ -48,6 +48,11 @@ def test_validate_preserve_errors(conf):
     assert not section['missing-subsection']
 
 
+def test_validate_strict_spec(conf):
+    conf['undefined-entry'] = True
+    assert not conf.validate(Validator(), strict_spec=True)
+
+
 def test_validate_extra_values(conf):
     conf.validate(Validator(), preserve_errors=True)
 


### PR DESCRIPTION
Implements a backwards compatible `strict_spec` validation mode:

If ``strict_spec`` is ``True`` (``False`` is default) then instead of
ignoring entries undefined by the configspec, unrecognized entries will
fail validation and be inserted into the return dictionary with an
informational ``ValidateError``.

Closes issue https://github.com/DiffSK/configobj/issues/125.