### PR TITLE
docs: import Validator from validate instead of configobj.validate

### DIFF
--- a/docs/configobj.rst
+++ b/docs/configobj.rst
@@ -531,7 +531,7 @@ validate
     # (which could also be hardcoded into your program)
     config = ConfigObj(filename, configspec=filename2)
     #
-    from configobj.validate import Validator
+    from validate import Validator
     val = Validator()
     test = config.validate(val)
     if test == True:
@@ -1832,7 +1832,7 @@ will be copied into your ConfigObj instance.
 .. code-block:: python
 
     from configobj import ConfigObj
-    from configobj.validate import Validator
+    from validate import Validator
     vdt = Validator()
     config = ConfigObj(configspec='default.ini')
     config.filename = 'new_default.ini'

--- a/docs/validate.rst
+++ b/docs/validate.rst
@@ -166,7 +166,7 @@ functions yourself.
 
 .. code-block:: python
 
-    from configobj.validate import Validator
+    from validate import Validator
     #
     vtor = Validator()
     newval1 = vtor.check('integer', value1)
@@ -196,14 +196,14 @@ Instantiate
 
 .. code-block:: python
 
-    from configobj.validate import Validator
+    from validate import Validator
     vtor = Validator()
 
 or even :
 
 .. code-block:: python
 
-    from configobj.validate import Validator
+    from validate import Validator
     #
     fdict = {
         'check_name1': function1,
@@ -231,7 +231,7 @@ same effect as the following code :
 
 .. code-block:: python
 
-    from configobj.validate import Validator
+    from validate import Validator
     #
     vtor = Validator()
     vtor.functions['check_name1'] = function1
@@ -267,7 +267,7 @@ that. Here's the basic example :
 
 .. code-block:: python
 
-    from configobj.validate import Validator, ValidateError
+    from validate import Validator, ValidateError
     #
     vtor = Validator()
     check = "integer(0, 9)"


### PR DESCRIPTION
Attempting to do `from configobj.validate import Validator` returns an error in the latest version of ConfigObj:

`ImportError: No module named 'configobj.validate'; 'configobj' is not a package`