### PR TITLE
Move some dottedQuadToNum doctests to pytest

### DIFF
--- a/src/configobj/validate.py
+++ b/src/configobj/validate.py
@@ -278,17 +278,8 @@ def dottedQuadToNum(ip):
 
     >>> int(dottedQuadToNum('1 '))
     1
-    >>> int(dottedQuadToNum(' 1.2'))
-    16777218
-    >>> int(dottedQuadToNum(' 1.2.3 '))
-    16908291
     >>> int(dottedQuadToNum('1.2.3.4'))
     16909060
-    >>> dottedQuadToNum('255.255.255.255')
-    4294967295
-    >>> dottedQuadToNum('255.255.255.256')
-    Traceback (most recent call last):
-    ValueError: Not a good dotted-quad IP: 255.255.255.256
     """
 
     # import here to avoid it when ip_addr values are not used

--- a/src/tests/test_validate.py
+++ b/src/tests/test_validate.py
@@ -212,3 +212,26 @@ class TestListChecks(object):
         configobj = ConfigObj(config, configspec=configspec)
         assert configobj.validate(val, preserve_errors=True) is True, "Validation failed unexpectedly"
         assert configobj['mixed'] == [1, '2', True, 3.1415]
+
+
+class TestDottedQuadToNum(object):
+
+    def test_stripped(self):
+        assert dottedQuadToNum('192.0.2.0') == 3221225984
+        assert dottedQuadToNum('192.0.2.1 ') == 3221225985
+        assert dottedQuadToNum(' 192.0.2.2') == 3221225986
+        assert dottedQuadToNum('\t\t192.0.2.3\n') == 3221225987
+        with pytest.raises(ValueError) as excinfo:
+            dottedQuadToNum('192. 0. 2. 4')
+        assert str(excinfo.value) == 'Not a good dotted-quad IP: 192. 0. 2. 4'
+
+    def test_boundaries(self):
+        assert dottedQuadToNum('0.0.0.0') == 0
+        assert dottedQuadToNum('255.255.255.255') == 4294967295
+        with pytest.raises(ValueError) as excinfo:
+            dottedQuadToNum('255.255.255.256')
+        assert str(excinfo.value) == (
+            'Not a good dotted-quad IP: 255.255.255.256')
+        with pytest.raises(ValueError) as excinfo:
+            dottedQuadToNum('-1')
+        assert str(excinfo.value) == 'Not a good dotted-quad IP: -1'


### PR DESCRIPTION
Currently the dottedQuadToNum doctest can fail on Python 2
depending on sys.maxint of the platform.

Really doctests are not suitable for full coverage, so the
boundary case and spacing behaviour checking is better
in the pytest framework with doctests reserved for showing
what the fuction actually does.