### PR TITLE
Always return unicode when encoding is given

### DIFF
--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -1465,14 +1465,14 @@ class ConfigObj(Section):
 
         if is a string, it also needs converting to a list.
         """
-        if isinstance(infile, six.string_types):
-            return infile.splitlines(True)
         if isinstance(infile, six.binary_type):
             # NOTE: Could raise a ``UnicodeDecodeError``
             if encoding:
                 return infile.decode(encoding).splitlines(True)
             else:
                 return infile.splitlines(True)
+        if isinstance(infile, six.string_types):
+            return infile.splitlines(True)
 
         if encoding:
             for i, line in enumerate(infile):

--- a/src/tests/test_configobj.py
+++ b/src/tests/test_configobj.py
@@ -240,6 +240,30 @@ class TestEncoding(object):
         assert isinstance(cfg['tags']['bug']['translated'], six.text_type)
         cfg.write()
 
+    #issue #18
+    def test_encoding_from_filelike(self):
+
+        class Filelike(object):
+            """Simple object that implements read() to return bytes"""
+
+            def __init__(self, data):
+                self.data = data
+
+            def read(self):
+                return self.data
+
+        c = ConfigObj(Filelike(b'string = \xc2\xa7'), encoding='utf-8')
+
+        string = c['string']
+
+        if six.PY2:
+            assert isinstance(string, unicode)
+        else:
+            assert isinstance(string, str)
+
+        assert string  == '\u00a7'
+
+
 @pytest.fixture
 def testconfig1():
     """


### PR DESCRIPTION
As reported in github issue #18 when a file-like object is
given and the encoding param is passed configobj fails to
decode the data on Python 2. This is a regression from
the 4.7 releases.

Fix is simply to check first for binary types in _decode()
helper as six.string_types includes the bytes str type
on Python 2.