### PR TITLE
Roundtrip configs with triple quotes and newlines

### DIFF
--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -1800,10 +1800,11 @@ class ConfigObj(Section):
         return quot
 
 
-    def _get_triple_quote(self, value):
+    @staticmethod
+    def _get_triple_quote(value):
         if (value.find('"""') != -1) and (value.find("'''") != -1):
             raise ConfigObjError('Value "%s" cannot be safely quoted.' % value)
-        if value.find('"""') == -1:
+        if value.find("'''") == -1:
             quot = tdquot
         else:
             quot = tsquot

--- a/src/tests/test_configobj.py
+++ b/src/tests/test_configobj.py
@@ -992,7 +992,7 @@ class TestInterpolation(object):
 
 class TestQuotes(object):
     """
-    tests what happens whn dealing with quotes
+    tests what happens when dealing with quotes
     """
     def assert_bad_quote_message(self, empty_cfg, to_quote, **kwargs):
         #TODO: this should be use repr instead of str
@@ -1023,6 +1023,23 @@ class TestQuotes(object):
             ConfigObj(testconfig5.splitlines())
         assert len(excinfo.value.errors) == 4
 
+    def test_triple_quote_newline_roundtrip(self):
+        """
+        Values with one kind of triple quote should save and load again.
+
+        From bzr bug lp:710410 and unit test written by bialix.
+        """
+        initial_conf = ConfigObj()
+        initial_conf['single'] = "single triple '''\n"
+        initial_conf['double'] = 'double triple """\n'
+
+        io = six.BytesIO()
+        initial_conf.write(outfile=io)
+        io.seek(0)
+
+        loaded_conf = ConfigObj(io)
+        assert loaded_conf['single'] == "single triple '''\n"
+        assert loaded_conf['double'] == 'double triple """\n'
 
 
 def test_handle_stringify_off():


### PR DESCRIPTION
Reported long ago as bzr bug lp:710410 but the fix never
made it to the 5.x configobj series.

It is possible to create a config which configobj cannot
read back, due to reversed logic in triple quote handling.

Adapted the bzr unit test by bialix and fixed the
behaviour.