### PR TITLE
Remove fallback for bool() not existing

### DIFF
--- a/src/configobj/validate.py
+++ b/src/configobj/validate.py
@@ -260,17 +260,6 @@ _paramstring = r'''
 
 _matchstring = '^%s*' % _paramstring
 
-# Python pre 2.2.1 doesn't have bool
-try:
-    bool
-except NameError:
-    def bool(val):
-        """Simple boolean equivalent function. """
-        if val:
-            return 1
-        else:
-            return 0
-
 
 def dottedQuadToNum(ip):
     """


### PR DESCRIPTION
Project only supports Pythons new enough to have the
bool() builtin these days.