### PR TITLE
Cleanup unrepr function and related code

### DIFF
--- a/src/tests/test_configobj.py
+++ b/src/tests/test_configobj.py
@@ -640,6 +640,23 @@ class TestUnrepr(object):
             'key4': [1, 2, 3, 'a mixed list#']
         }
 
+    def test_empty_value(self):
+        cfg = ConfigObj(['k = '], unrepr=True)
+        assert cfg == {'k': ''}
+
+    def test_unclosed_quote(self):
+        with pytest.raises(co.UnreprError) as excinfo:
+            ConfigObj(['k = "'], unrepr=True)
+        assert str(excinfo.value) == (
+            "Parse error from unrepr-ing value at line 1.")
+
+    def test_multiline_string_empty(self):
+        config = ['k = """', '"""']
+        with pytest.raises(co.UnreprError) as excinfo:
+            ConfigObj(config, unrepr=True)
+        assert str(excinfo.value) == (
+            "Parse error from unrepr-ing multiline value at line 2.")
+
 
 class TestValueErrors(object):
     def test_bool(self, empty_cfg):


### PR DESCRIPTION
There was some cruft left around from the old implemention
of unrepr, which can now be deleted.

Not sure if the lazy import of ast is worthwhile but the
implemention of that is now pretty harmless.

Note this does remove the exported but unused, and only
ever internally propogated, UnknownType exception type.

Also adds test coverage for some unrepr corner cases.