### PR TITLE
Delete the _a_to_u() helper method

### DIFF
--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -1518,6 +1518,7 @@ class ConfigObj(Section):
         maxline = len(infile) - 1
         cur_index = -1
         reset_comment = False
+        comment_markers = tuple(self.COMMENT_MARKERS)
 
         while cur_index < maxline:
             if reset_comment:
@@ -1526,7 +1527,7 @@ class ConfigObj(Section):
             line = infile[cur_index]
             sline = line.strip()
             # do we have anything on the line ?
-            if not sline or any(sline.startswith(x) for x in self.COMMENT_MARKERS):
+            if not sline or sline.startswith(comment_markers):
                 reset_comment = False
                 comment_list.append(line)
                 continue
@@ -1993,8 +1994,8 @@ class ConfigObj(Section):
             self.indent_type = DEFAULT_INDENT_TYPE
 
         out = []
-        comment_markers = [x for x in self.COMMENT_MARKERS]
-        comment_marker_default = self.COMMENT_MARKERS[0] + ' '
+        comment_markers = tuple(self.COMMENT_MARKERS)
+        comment_marker_default = comment_markers[0] + ' '
         if section is None:
             int_val = self.interpolation
             self.interpolation = False
@@ -2002,7 +2003,7 @@ class ConfigObj(Section):
             for line in self.initial_comment:
                 line = self._decode_element(line)
                 stripped_line = line.strip()
-                if stripped_line and not any(stripped_line.startswith(x) for x in comment_markers):
+                if stripped_line and not stripped_line.startswith(comment_markers):
                     line = comment_marker_default + line
                 out.append(line)
 
@@ -2013,7 +2014,7 @@ class ConfigObj(Section):
                 continue
             for comment_line in section.comments[entry]:
                 comment_line = self._decode_element(comment_line.lstrip())
-                if comment_line and not any(comment_line.startswith(x) for x in comment_markers):
+                if comment_line and not comment_line.startswith(comment_markers):
                     comment_line = comment_marker_default + comment_line
                 out.append(indent_string + comment_line)
             this_entry = section[entry]
@@ -2038,7 +2039,7 @@ class ConfigObj(Section):
             for line in self.final_comment:
                 line = self._decode_element(line)
                 stripped_line = line.strip()
-                if stripped_line and not any(stripped_line.startswith(x) for x in comment_markers):
+                if stripped_line and not stripped_line.startswith(comment_markers):
                     line = comment_marker_default + line
                 out.append(line)
             self.interpolation = int_val

--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -1459,14 +1459,6 @@ class ConfigObj(Section):
             return self._decode(infile, 'utf-8')
 
 
-    def _a_to_u(self, aString):
-        """Decode ASCII strings to unicode if a self.encoding is specified."""
-        if isinstance(aString, six.binary_type) and self.encoding:
-            return aString.decode(self.encoding)
-        else:
-            return aString
-
-
     def _decode(self, infile, encoding):
         """
         Decode infile to unicode. Using the specified encoding.
@@ -1950,7 +1942,7 @@ class ConfigObj(Section):
             val = repr(this_entry)
         return '%s%s%s%s%s' % (indent_string,
                                self._decode_element(self._quote(entry, multiline=False)),
-                               self._a_to_u(' = '),
+                               ' = ',
                                val,
                                self._decode_element(comment))
 
@@ -1963,9 +1955,9 @@ class ConfigObj(Section):
             # titles are in '[]' already, so quoting for contained quotes is not necessary (#74)
             title = entry_str
         return '%s%s%s%s%s' % (indent_string,
-                               self._a_to_u('[' * depth),
+                               '[' * depth,
                                title,
-                               self._a_to_u(']' * depth),
+                               ']' * depth,
                                self._decode_element(comment))
 
 
@@ -1975,7 +1967,7 @@ class ConfigObj(Section):
             return comment or ''  # return trailing whitespace as-is
         start = self.indent_type
         if not comment.lstrip().startswith('#'):
-            start += self._a_to_u(' # ')
+            start += ' # '
         return (start + comment)
 
 
@@ -2001,8 +1993,8 @@ class ConfigObj(Section):
             self.indent_type = DEFAULT_INDENT_TYPE
 
         out = []
-        comment_markers = [self._a_to_u(x) for x in self.COMMENT_MARKERS]
-        comment_marker_default = self._a_to_u(self.COMMENT_MARKERS[0] + ' ')
+        comment_markers = [x for x in self.COMMENT_MARKERS]
+        comment_marker_default = self.COMMENT_MARKERS[0] + ' '
         if section is None:
             int_val = self.interpolation
             self.interpolation = False
@@ -2074,7 +2066,7 @@ class ConfigObj(Section):
             and sys.platform == 'win32' and newline == '\r\n'):
             # Windows specific hack to avoid writing '\r\r\n'
             newline = '\n'
-        output = self._a_to_u(newline).join(out)
+        output = newline.join(out)
         if not output.endswith(newline):
             output += newline
 


### PR DESCRIPTION
Well meaning attempt at encoding correctness, but does
literal nothing. On Python 3, ascii values are already
decoded, on Python 2 ascii will get safely coerced to
unicode.