### PR TITLE
changed import from configobj.validate to validate

### DIFF
--- a/docs/configobj.rst
+++ b/docs/configobj.rst
@@ -531,7 +531,7 @@ validate
     # (which could also be hardcoded into your program)
     config = ConfigObj(filename, configspec=filename2)
     #
-    from configobj.validate import Validator
+    from validate import Validator
     val = Validator()
     test = config.validate(val)
     if test == True:
@@ -1832,7 +1832,7 @@ will be copied into your ConfigObj instance.
 .. code-block:: python
 
     from configobj import ConfigObj
-    from configobj.validate import Validator
+    from validate import Validator
     vdt = Validator()
     config = ConfigObj(configspec='default.ini')
     config.filename = 'new_default.ini'

--- a/docs/validate.rst
+++ b/docs/validate.rst
@@ -166,7 +166,7 @@ functions yourself.
 
 .. code-block:: python
 
-    from configobj.validate import Validator
+    from validate import Validator
     #
     vtor = Validator()
     newval1 = vtor.check('integer', value1)
@@ -196,14 +196,14 @@ Instantiate
 
 .. code-block:: python
 
-    from configobj.validate import Validator
+    from validate import Validator
     vtor = Validator()
 
 or even :
 
 .. code-block:: python
 
-    from configobj.validate import Validator
+    from validate import Validator
     #
     fdict = {
         'check_name1': function1,
@@ -231,7 +231,7 @@ same effect as the following code :
 
 .. code-block:: python
 
-    from configobj.validate import Validator
+    from validate import Validator
     #
     vtor = Validator()
     vtor.functions['check_name1'] = function1
@@ -267,7 +267,7 @@ that. Here's the basic example :
 
 .. code-block:: python
 
-    from configobj.validate import Validator, ValidateError
+    from validate import Validator, ValidateError
     #
     vtor = Validator()
     check = "integer(0, 9)"

--- a/docs/validate.rst
+++ b/docs/validate.rst
@@ -483,16 +483,16 @@ Any other type is a ``VdtTypeError``, any other value is a
             if not isinstance(entry, (str, unicode, int)):
                 # a value in the list
                 # is neither an integer nor a string
-                raise VdtTypeError(value)
+                raise VdtTypeError(entry)
             elif isinstance(entry, (str, unicode)):
                 if not entry.isdigit():
-                    raise VdtTypeError(value)
+                    raise VdtTypeError(entry)
                 else:
                     entry = int(entry)
             if entry < 0:
-                raise VdtValueTooSmallError(value)
+                raise VdtValueTooSmallError(entry)
             elif entry > 99:
-                raise VdtValueTooBigError(value)
+                raise VdtValueTooBigError(entry)
             out.append(entry)
         #
         # if we got this far, all is well

--- a/docs/validate.rst
+++ b/docs/validate.rst
@@ -453,6 +453,8 @@ Any other type is a ``VdtTypeError``, any other value is a
 .. code-block:: python
 
     def special_list(value, length):
+        #Make sure to import all exceptions that will be used
+        from validate import VdtParamError, VdtTypeError, VdtValueTooLongError, VdtValueTooShortError,VdtTypeError, VdtValueTooSmallError, VdtValueTooBigError
         """
         Check that the supplied value is a list of integers,
         with 'length' entries, and each entry between 0 and 99.


### PR DESCRIPTION
When attempting to use current documentation by copying and pasting into an iPython env python was not able to import. Seems like the import may have just been out of date. Using validate instead of configobj.validate works.