### PR TITLE
Drop support for EOL Python 2.6 and 3.3

### DIFF
--- a/.env
+++ b/.env
@@ -30,7 +30,7 @@ if $_venv_py3; then # Python 3 mode?
         _venv_virtualenv=$_venv_temp
     fi
     # python3 venv in recent Debian / Ubuntu
-    for _venv_temp in 3 3.6 3.5 3.4 3.3; do
+    for _venv_temp in 3 3.6 3.5 3.4; do
         _venv_temp=/usr/bin/pyvenv-$_venv_temp
         if test -x $_venv_temp; then
             _venv_virtualenv=$_venv_temp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 sudo: false
 language: python
 python:
-  - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+Unreleased
+""""""""""
+
+* Drop support for EOL Python 2.6 and 3.3
+
+
 Release 5.1.0
 """""""""""""
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ This project is now maintained by [Eli Courtwright](https://github.com/EliAndrew
 
 For long time ConfigObj users, the biggest change is in the officially supported Python versions (it *was* 2.3 … 2.6):
 
-* 2.6 … 2.7
-* 3.3 … 3.6
+* 2.7
+* 3.4 … 3.6
 
 Other Python3 versions may work, but this is what *Travis* and ``tox`` use to run the tests on commit.
 

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ try:
         LONG_DESCRIPTION += handle.read()
 except EnvironmentError as exc:
     # Build / install anyway
-    print("WARNING: Cannot open/read CHANGES.rst due to {0}".format(exc))
+    print("WARNING: Cannot open/read CHANGES.rst due to {}".format(exc))
 
 CLASSIFIERS = [
     # Details at http://pypi.python.org/pypi?:action=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,12 @@ from contextlib import closing
 from setuptools import setup
 
 if sys.version_info < (2, 6):
-    print('for python versions < 2.6 use configobj '
+    print('for Python versions < 2.6 use configobj '
           'version 4.7.2')
+    sys.exit(1)
+elif sys.version_info < (2, 7):
+    print('for Python version 2.6 use configobj '
+          'version 5.0.5')
     sys.exit(1)
 
 __here__ = os.path.abspath(os.path.dirname(__file__))
@@ -85,10 +89,8 @@ CLASSIFIERS = [
     'License :: OSI Approved :: BSD License',
     'Programming Language :: Python',
     'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
@@ -115,6 +117,7 @@ project = dict(
     package_dir={'': 'src'},
     packages=PACKAGES,
     install_requires=[i.strip() for i in REQUIRES.splitlines() if i.strip()],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=CLASSIFIERS,
     keywords=KEYWORDS,
     license='BSD (2 clause)',

--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -693,7 +693,7 @@ class Section(dict):
                 return self[key]
             except MissingInterpolationOption:
                 return dict.__getitem__(self, key)
-        return '{%s}' % ', '.join([('%s: %s' % (repr(key), repr(_getval(key))))
+        return '{%s}' % ', '.join([('{}: {}'.format(repr(key), repr(_getval(key))))
             for key in (self.scalars + self.sections)])
 
     __str__ = __repr__
@@ -1026,7 +1026,7 @@ class Section(dict):
 def _get_triple_quote(value):
     """Helper for triple-quoting round-trips."""
     if ('"""' in value) and ("'''" in value):
-        raise ConfigObjError('Value cannot be safely quoted: {0!r}'.format(value))
+        raise ConfigObjError('Value cannot be safely quoted: {!r}'.format(value))
 
     return tsquot if "'''" in value else tdquot
 
@@ -1275,11 +1275,11 @@ class ConfigObj(Section):
         # if we had any errors, now is the time to raise them
         if self._errors:
             if len(self._errors) > 1:
-                msg = ["Parsing failed with {0} errors.".format(len(self._errors))]
+                msg = ["Parsing failed with {} errors.".format(len(self._errors))]
                 for error in self._errors[:self.MAX_PARSE_ERROR_DETAILS]:
                     msg.append(str(error))
                 if len(self._errors) > self.MAX_PARSE_ERROR_DETAILS:
-                    msg.append("{0} more error(s)!"
+                    msg.append("{} more error(s)!"
                                .format(len(self._errors) - self.MAX_PARSE_ERROR_DETAILS))
                 error = ConfigObjError('\n    '.join(msg))
             else:
@@ -1337,8 +1337,8 @@ class ConfigObj(Section):
                 return self[key]
             except MissingInterpolationOption:
                 return dict.__getitem__(self, key)
-        return ('%s({%s})' % (self.__class__.__name__,
-                ', '.join([('%s: %s' % (repr(key), repr(_getval(key))))
+        return ('{}({{{}}})'.format(self.__class__.__name__,
+                ', '.join([('{}: {}'.format(repr(key), repr(_getval(key))))
                 for key in (self.scalars + self.sections)])))
 
 
@@ -1601,7 +1601,7 @@ class ConfigObj(Section):
             mat = self._keyword.match(line)
             if mat is None:
                 self._handle_error(
-                    'Invalid line ({0!r}) (matched as neither section nor keyword)'.format(line),
+                    'Invalid line ({!r}) (matched as neither section nor keyword)'.format(line),
                     ParseError, infile, cur_index)
             else:
                 # is a keyword value
@@ -1707,7 +1707,7 @@ class ConfigObj(Section):
         """
         line = infile[cur_index]
         cur_index += 1
-        message = '{0} at line {1}.'.format(text, cur_index)
+        message = '{} at line {}.'.format(text, cur_index)
         error = ErrorClass(message, cur_index, line)
         if self.raise_errors:
             # raise the error - parsing stops here
@@ -1781,7 +1781,7 @@ class ConfigObj(Section):
             # for normal values either single or double quotes will do
             elif '\n' in value:
                 # will only happen if multiline is off - e.g. '\n' in key
-                raise ConfigObjError('Value cannot be safely quoted: {0!r}'.format(value))
+                raise ConfigObjError('Value cannot be safely quoted: {!r}'.format(value))
             elif ((value[0] not in wspace_plus) and
                     (value[-1] not in wspace_plus) and
                     (',' not in value)):
@@ -1800,7 +1800,7 @@ class ConfigObj(Section):
 
     def _get_single_quote(self, value):
         if ("'" in value) and ('"' in value):
-            raise ConfigObjError('Value cannot be safely quoted: {0!r}'.format(value))
+            raise ConfigObjError('Value cannot be safely quoted: {!r}'.format(value))
         elif '"' in value:
             quot = squot
         else:

--- a/src/configobj/validate.py
+++ b/src/configobj/validate.py
@@ -372,7 +372,7 @@ class VdtUnknownCheckError(ValidateError):
         Traceback (most recent call last):
         VdtUnknownCheckError: the check "yoda" is unknown.
         """
-        ValidateError.__init__(self, 'the check "%s" is unknown.' % (value,))
+        ValidateError.__init__(self, 'the check "{}" is unknown.'.format(value))
 
 
 class VdtParamError(SyntaxError):
@@ -392,7 +392,7 @@ class VdtParamError(SyntaxError):
         if value is self.NOT_GIVEN:
             SyntaxError.__init__(self, name_or_msg)
         else:
-            SyntaxError.__init__(self, 'passed an incorrect value "%s" for parameter "%s".' % (value, name_or_msg))
+            SyntaxError.__init__(self, 'passed an incorrect value "{}" for parameter "{}".'.format(value, name_or_msg))
 
 
 class VdtTypeError(ValidateError):
@@ -404,7 +404,7 @@ class VdtTypeError(ValidateError):
         Traceback (most recent call last):
         VdtTypeError: the value "jedi" is of the wrong type.
         """
-        ValidateError.__init__(self, 'the value "%s" is of the wrong type.' % (value,))
+        ValidateError.__init__(self, 'the value "{}" is of the wrong type.'.format(value))
 
 
 class VdtValueError(ValidateError):
@@ -416,7 +416,7 @@ class VdtValueError(ValidateError):
         Traceback (most recent call last):
         VdtValueError: the value "jedi" is unacceptable.
         """
-        ValidateError.__init__(self, 'the value "%s" is unacceptable.' % (value,))
+        ValidateError.__init__(self, 'the value "{}" is unacceptable.'.format(value))
 
 
 class VdtValueTooSmallError(VdtValueError):
@@ -428,7 +428,7 @@ class VdtValueTooSmallError(VdtValueError):
         Traceback (most recent call last):
         VdtValueTooSmallError: the value "0" is too small.
         """
-        ValidateError.__init__(self, 'the value "%s" is too small.' % (value,))
+        ValidateError.__init__(self, 'the value "{}" is too small.'.format(value))
 
 
 class VdtValueTooBigError(VdtValueError):
@@ -440,7 +440,7 @@ class VdtValueTooBigError(VdtValueError):
         Traceback (most recent call last):
         VdtValueTooBigError: the value "1" is too big.
         """
-        ValidateError.__init__(self, 'the value "%s" is too big.' % (value,))
+        ValidateError.__init__(self, 'the value "{}" is too big.'.format(value))
 
 
 class VdtValueTooShortError(VdtValueError):
@@ -454,7 +454,7 @@ class VdtValueTooShortError(VdtValueError):
         """
         ValidateError.__init__(
             self,
-            'the value "%s" is too short.' % (value,))
+            'the value "{}" is too short.'.format(value))
 
 
 class VdtValueTooLongError(VdtValueError):
@@ -466,7 +466,7 @@ class VdtValueTooLongError(VdtValueError):
         Traceback (most recent call last):
         VdtValueTooLongError: the value "jedie" is too long.
         """
-        ValidateError.__init__(self, 'the value "%s" is too long.' % (value,))
+        ValidateError.__init__(self, 'the value "{}" is too long.'.format(value))
 
 
 class Validator(object):
@@ -644,7 +644,7 @@ class Validator(object):
             fun_kwargs = dict(fun_kwargs)
         else:
             fun_name, fun_args, fun_kwargs, default = self._parse_check(check)
-            fun_kwargs = dict([(str(key), value) for (key, value) in list(fun_kwargs.items())])
+            fun_kwargs = {str(key): value for (key, value) in list(fun_kwargs.items())}
             self._cache[check] = fun_name, list(fun_args), dict(fun_kwargs), default
         return fun_name, fun_args, fun_kwargs, default
 
@@ -1480,6 +1480,6 @@ if __name__ == '__main__':
     failures, tests = doctest.testmod(
         m, globs=globs,
         optionflags=doctest.IGNORE_EXCEPTION_DETAIL | doctest.ELLIPSIS)
-    print('{0} {1} failures out of {2} tests'
+    print('{} {} failures out of {} tests'
           .format("FAIL" if failures else "*OK*", failures, tests))
     sys.exit(bool(failures))

--- a/src/tests/configobj_doctests.py
+++ b/src/tests/configobj_doctests.py
@@ -981,7 +981,7 @@ if __name__ == '__main__':
     post_failures, post_tests = doctest.testmod(
         configobj, globs=globs,
         optionflags=doctest.IGNORE_EXCEPTION_DETAIL | doctest.ELLIPSIS)
-    print('{0} {1} failures out of {2} tests'
+    print('{} {} failures out of {} tests'
           .format("FAIL" if post_failures or pre_failures else "*OK*",
                   post_failures + pre_failures, post_tests + pre_tests))
     sys.exit(bool(post_failures or pre_failures))

--- a/src/tests/test_validate.py
+++ b/src/tests/test_validate.py
@@ -207,7 +207,7 @@ class TestListChecks(object):
             mixed = 1, 2, yes, 3.1415
             '''.splitlines()
         configspec = '''
-            mixed = mixed_list({0})
+            mixed = mixed_list({})
             '''.format(typespec).splitlines()
         configobj = ConfigObj(config, configspec=configspec)
         assert configobj.validate(val, preserve_errors=True) is True, "Validation failed unexpectedly"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini, put in same dir as setup.py
 [tox]
-envlist = py26,py27,py33,py34,py35,py36
+envlist = py27, py34, py35, py36
 
 
 [testenv]


### PR DESCRIPTION
Python 2.6 and 3.3 are EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.6 | 2008-10-01 | 2013-10-29
3.3 | 2012-09-29 | 2017-09-29

Source: https://en.wikipedia.org/wiki/CPython#Version_history

They're also little used.

Here's the pip installs for configobj from PyPI for September 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  76.56% |        607,597 |
| 3.4            |  13.42% |        106,487 |
| 3.6            |   5.52% |         43,824 |
| 3.7            |   2.84% |         22,520 |
| 3.5            |   1.54% |         12,231 |
| 2.6            |   0.11% |            875 |
| 3.3            |   0.01% |             65 |
| 3.2            |   0.00% |              6 |
| 3.8            |   0.00% |              2 |
| Total          |         |        793,607 |

Source: `pypinfo --start-date 2018-09-01 --end-date 2018-09-30 --percent --markdown configobj pyversion`

Finally, they're failing the build (see PR https://github.com/DiffSK/configobj/pull/172,  https://travis-ci.org/DiffSK/configobj/builds/440978367) due to other dependencies having already dropped them, as the Python community is generally doing.