### PR TITLE
Support for loading config object from "<(/usr/bin/envsubst < template)"

### DIFF
--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -1212,7 +1212,7 @@ class ConfigObj(Section):
 
         if isinstance(infile, six.string_types):
             self.filename = infile
-            if os.path.isfile(infile):
+            if os.path.exists(infile):
                 with open(infile, 'rb') as h:
                     content = h.readlines() or []
             elif self.file_error:


### PR DESCRIPTION
configobj has an issue being passed a file descriptor (/dev/fd) via [process substitution](http://www.tldp.org/LDP/abs/html/process-sub.html).

`os.path.isfile("/dev/fd/{{ anything }}")` returns `False` for file descriptors while [`os.path.exists()`](https://docs.python.org/3.5/library/os.path.html#os.path.exists) returns `True`.

test.py
```
#!/usr/bin/python
import sys
import configobj

print configobj.ConfigObj(sys.argv[1])
```
I'll update the PR with a test when I get a chance
```
$ cat foo.ini 
shell = /bin/bash
$ cat bar.ini.template 
shell = $SHELL
$ ./test.py foo.ini 
{'shell': '/bin/bash'}
$ ./test.py <(envsubst < bar.ini.template )
{'shell': '/bin/bash'}
```

This is needed in cloud environments where you may not want to store passwords on disk in an unencrypted form or have variables passed into a container environment.