### PR TITLE
Makes sure that values fully encased in quotes are not doubly quoted.

### DIFF
--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -1804,6 +1804,10 @@ class ConfigObj(Section):
     def _get_single_quote(self, value):
         if ("'" in value) and ('"' in value):
             raise ConfigObjError('Value cannot be safely quoted: {!r}'.format(value))
+        elif re.match('".*"', value) is not None:
+            quot = noquot
+        elif re.match("'.*'", value) is not None:
+            quot = noquot
         elif '"' in value:
             quot = squot
         else:


### PR DESCRIPTION
Fixes #198. 

I ran `invoke ci`, and my change does not seem to change the output at all.  Hopefully this change makes sense.