### PR TITLE
Handle pipes via process substitution

### DIFF
--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -1212,7 +1212,7 @@ class ConfigObj(Section):
 
         if isinstance(infile, six.string_types):
             self.filename = infile
-            if os.path.isfile(infile):
+            if os.path.isfile(infile) or os.path.islink(infile):
                 with open(infile, 'rb') as h:
                     content = h.readlines() or []
             elif self.file_error:


### PR DESCRIPTION
FWIW I'm not a python developer so this code may have repercussions that I'm unable to diagnose.

## Background

I'm doing some manual templating on config files for two programs: khal and khard, both of which use configobj. Neither program allows for interpolation in the config files, so I was required to roll my own. Essentially, I run these programs with a wrapper like this:

```
#!/usr/bin/env bash
source pimenv

/usr/bin/khal -c <(envsubst < "$XDG_CONFIG_HOME/khal/config") "$@"
```

Sourcing `pimenv` provides a bunch of environment variables which are interpolated into the config file using envsubst with process substitution, producing a file descriptor (`/dev/fd/63`).

On Linux, at least, `os.path.isfile()` returns `False` for this descriptor, but `os.path.islink()` returns True. As a result, even though the file is readable, configobj never tries to read it and throws an error.

## The Fix

Well, the code is pretty self-explanatory. I've tested this under both khal and khard, and found that everything works as expected now. Interestingly, `os.path.isfile()` does return True for a symlink, so this is probably quite an edge case.

