### PR TITLE
Preserve comments on merge.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,8 +2,8 @@
 # Development requirements
 #
 
-invoke==0.12.2
-#rituals==0.3.0
+# invoke==0.12.2
+# rituals==0.3.0
 -e git+https://github.com/jhermann/rituals.git#egg=rituals
 
 Sphinx==1.3.4

--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -760,6 +760,14 @@ class Section(dict):
         >>> c2
         ConfigObj({'section1': {'option1': 'False', 'subsection': {'more_options': 'False'}}})
         """
+        if hasattr(indict, "initial_comment") and indict.initial_comment:
+            self.initial_comment = indict.initial_comment
+        if hasattr(indict, "final_comment") and indict.final_comment:
+            self.final_comment = indict.final_comment
+        if hasattr(indict, "comments") and indict.comments:
+            for k, comment_lines in indict.comments.items():
+                if comment_lines:
+                    self.comments[k] = comment_lines
         for key, val in indict.items():
             if decoupled:
                 val = copy.deepcopy(val)

--- a/src/tests/test_configobj.py
+++ b/src/tests/test_configobj.py
@@ -1299,6 +1299,36 @@ class TestMerging(object):
         c1['sect']['val'] = 42
         assert c2['sect']['val'] == data[1]
 
+    @pytest.mark.parametrize(
+        "lines1,lines2,expected_lines",
+        [
+            (
+                # both c1 and c2 have comments
+                ["# c1 before config", "[main]", "# c1 for foo", "foo = a", "# c1 after config"],
+                ["# c2 before config", "[main]", "# c2 for foo", "foo = b", "# c2 after config"],
+                ["# c2 before config", "[main]", "# c2 for foo", "foo = b", "# c2 after config"],
+            ),
+            (
+                # c1 has comments, c2 does not
+                ["# c1 before config", "[main]", "# c1 for foo", "foo = a", "# c1 after config"],
+                ["[main]", "foo = b"],
+                ["# c1 before config", "[main]", "# c1 for foo", "foo = b", "# c1 after config"],
+            ),
+            (
+                # c2 has comments, c1 does not
+                ["[main]", "foo = a"],
+                ["# c2 before config", "[main]", "# c2 for foo", "foo = b", "# c2 after config"],
+                ["# c2 before config", "[main]", "# c2 for foo", "foo = b", "# c2 after config"],
+            ),
+        ]
+    )
+    def test_merge_comments(self, lines1, lines2, expected_lines):
+        c1 = ConfigObj(lines1)
+        c2 = ConfigObj(lines2)
+        c1.merge(c2)
+        # comments and values from c2 should win
+        actual_lines = c1.write()
+        assert actual_lines == expected_lines
 
 class TestErrorReporting(object):
     MULTI_ERROR = [


### PR DESCRIPTION
This fixes https://github.com/DiffSK/configobj/issues/171. If we're merging config2 into config1, then values from config2, if present, should override values from config1. The same thing needs to happen with comments, but currently it does not.

Related to https://github.com/dbcli/pgcli/issues/1240.

- [x] Run the tests and make sure they're passing (invoke test).
- [ ] Check for violations of code conventions (invoke check).
- [x] Make sure the documentation builds without errors (invoke build --docs).

I have an error running `invoke check` and could not resolve it by googling, would appreciate advice on that:

https://gist.github.com/j-bennet/392e90ed75873a69b465e32dd6763476