### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/configobj.rst
+++ b/docs/configobj.rst
@@ -1604,7 +1604,7 @@ message will be raised.
 Unless you want to format the error message differently from the default, you
 should use ``str(ex)`` or better yet, use the exception in a format where the
 conversion is implicit. This uses the exception's ``__str__()`` method which in all
-likelyhood will output all the information you want to know.
+likelihood will output all the information you want to know.
 
 .. note::
 

--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -201,7 +201,7 @@ class DuplicateError(ConfigObjError):
 
 class ConfigspecError(ConfigObjError):
     """
-    An error occured whilst parsing a configspec.
+    An error occurred whilst parsing a configspec.
     """
 
 
@@ -1706,7 +1706,7 @@ class ConfigObj(Section):
         Handle an error according to the error settings.
 
         Either raise the error or store it.
-        The error will have occured at ``cur_index``
+        The error will have occurred at ``cur_index``
         """
         line = infile[cur_index]
         cur_index += 1


### PR DESCRIPTION
There are small typos in:
- docs/configobj.rst
- src/configobj/__init__.py

Fixes:
- Should read `occurred` rather than `occured`.
- Should read `likelihood` rather than `likelyhood`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md