### PR TITLE
Add a pyproject.toml file ahead of upcoming pip changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Add a pyproject.toml file ahead of upcoming pip changes

This simply declares that the project uses setuptools.
