### PR TITLE
When writing an inline comment with a leading `#` put a space between the value and the `#`

### DIFF
--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -2000,6 +2000,8 @@ class ConfigObj(Section):
         start = self.indent_type
         if not comment.startswith('#'):
             start += self._a_to_u(' # ')
+        else:
+            start += self._a_to_u(' ')
         return (start + comment)
 
 

--- a/src/tests/test_configobj.py
+++ b/src/tests/test_configobj.py
@@ -542,13 +542,13 @@ class TestWritingConfigs(object):
             'key1 = Hello',
             '',
             '# section comment',
-            '[section]# inline comment',
+            '[section] # inline comment',
             '# key1 comment',
             'key1 = 6',
             '# key2 comment',
             'key2 = True',
             '# subsection comment',
-            '[[sub-section]]# inline comment',
+            '[[sub-section]] # inline comment',
             '# another key1 comment',
             'key1 = 3.0'
         ]
@@ -560,9 +560,9 @@ class TestWritingConfigs(object):
             'key2 =# a comment',
         ]
         cfg = ConfigObj(config_with_empty_values)
-        assert cfg.write() == ['', 'key1 = ""', 'key2 = ""# a comment']
+        assert cfg.write() == ['', 'key1 = ""', 'key2 = "" # a comment']
         cfg.write_empty_values = True
-        assert cfg.write() == ['', 'key1 = ', 'key2 = # a comment']
+        assert cfg.write() == ['', 'key1 = ', 'key2 =  # a comment']
 
 
 class TestUnrepr(object):
@@ -1162,6 +1162,12 @@ class TestComments(object):
         c = ConfigObj()
         c['foo'] = 'bar'
         c.inline_comments['foo'] = 'Nice bar'
+        assert c.write() == ['foo = bar # Nice bar']
+
+    def test_inline_comments_with_leading_number_sign(self):
+        c = ConfigObj()
+        c['foo'] = 'bar'
+        c.inline_comments['foo'] = '# Nice bar'
         assert c.write() == ['foo = bar # Nice bar']
 
     def test_unrepr_comments(self, comment_filled_cfg):


### PR DESCRIPTION
Fixes #261