### PR TITLE
Document release and master branches in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ This is a mature project that is only being maintained for bug fixes and
 compatibility with new versions of Python. It is not under active development,
 though we will try to respond to issues and pull requests.
 
+## Branches
+
+The default branch of this repository is the [`release` branch](https://github.com/DiffSK/configobj/tree/release),
+rather than the [`master` branch](https://github.com/DiffSK/configobj/tree/master).
+This decision dates back to when this project moved from being actively
+maintained to it's current state as a mature project.
+At that time (in 2023), [changes introduced](https://github.com/DiffSK/configobj/compare/v5.0.6...master)
+into the `master` branch had not been fully integrated, and the tooling had
+shifted in ways that made [continuing from `master` unclear](https://github.com/DiffSK/configobj/pull/237#issuecomment-1925401612).
+
+Instead, [we chose to continue development](https://github.com/DiffSK/configobj/issues/213#issuecomment-1377686121)
+from the `5.0.6` release branch. Any changes made to master after that release
+were effectively abandoned, and the `release` branch has served as the main
+line of development since.
+
+As a result, going forward, new pull requests should be made against the
+`release` branch as the `master` branch is frozen in time.
+
 ## Past and Current Contributors:
 
 - [Michael Foord](https://agileabstractions.com/)

--- a/README.md
+++ b/README.md
@@ -30,18 +30,22 @@ though we will try to respond to issues and pull requests.
 The default branch of this repository is the [`release` branch](https://github.com/DiffSK/configobj/tree/release),
 rather than the [`master` branch](https://github.com/DiffSK/configobj/tree/master).
 This decision dates back to when this project moved from being actively
-maintained to it's current state as a mature project.
+maintained to its current state as a mature project.
 At that time (in 2023), [changes introduced](https://github.com/DiffSK/configobj/compare/v5.0.6...master)
 into the `master` branch had not been fully integrated, and the tooling had
 shifted in ways that made [continuing from `master` unclear](https://github.com/DiffSK/configobj/pull/237#issuecomment-1925401612).
 
 Instead, [we chose to continue development](https://github.com/DiffSK/configobj/issues/213#issuecomment-1377686121)
-from the `5.0.6` release branch. Any changes made to master after that release
-were effectively abandoned, and the `release` branch has served as the main
-line of development since.
+from the `5.0.6` release branch. Any changes made to `master` after that release
+were effectively abandoned, and the [`release` branch](https://github.com/DiffSK/configobj/tree/release) has served as
+the main line of development since.
 
-As a result, going forward, new pull requests should be made against the
-`release` branch as the `master` branch is frozen in time.
+As a result, going forward :
+
+* Pull requests for feature changes / refactoring should be made against the `master` branch
+* Pull requests for bug fixes should be made against the [`5.0.x`](https://github.com/DiffSK/configobj/tree/5.0.x)
+  branch. Those changes, once merged into [`5.0.x`](https://github.com/DiffSK/configobj/tree/5.0.x), will later be
+  merged into the [`master`](https://github.com/DiffSK/configobj/tree/master) branch.
 
 ## Past and Current Contributors:
 


### PR DESCRIPTION
Fixes #263

This was originally opened in #265 against the `release` branch instead of the `5.0.x` branch.