### PR TITLE
Quote keys containing '=' when writing (fixes #273)

### DIFF
--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -1760,7 +1760,7 @@ class ConfigObj(Section):
         return value
 
 
-    def _quote(self, value, multiline=True):
+    def _quote(self, value, multiline=True, is_key=False):
         """
         Return a safely quoted version of a value.
         
@@ -1808,7 +1808,12 @@ class ConfigObj(Section):
         check_for_single = (no_lists_no_quotes or not need_triple) and not hash_triple_quote
         
         if check_for_single:
-            if not self.list_values:
+            if is_key and '=' in value:
+                # A key containing '=' must be quoted, otherwise the first
+                # '=' is read back as the key/value divider, splitting the
+                # key and corrupting the value on the next parse.
+                quot = self._get_single_quote(value)
+            elif not self.list_values:
                 # we don't quote if ``list_values=False``
                 quot = noquot
             # for normal values either single or double quotes will do
@@ -1992,7 +1997,7 @@ class ConfigObj(Section):
         else:
             val = repr(this_entry)
         return '%s%s%s%s%s' % (indent_string,
-                               self._decode_element(self._quote(entry, multiline=False)),
+                               self._decode_element(self._quote(entry, multiline=False, is_key=True)),
                                self._a_to_u(' = '),
                                val,
                                self._decode_element(comment))

--- a/src/tests/test_configobj.py
+++ b/src/tests/test_configobj.py
@@ -1295,6 +1295,19 @@ class TestEdgeCasesWhenWritingOut(object):
         empty_cfg.write(collector)
         assert collector.getvalue() == b'a = "b # something", "c # something"\n'
 
+    def test_key_with_equals_is_quoted(self, empty_cfg):
+        # issue #273: a key containing '=' was written unquoted, so on the
+        # next parse the first '=' was read as the key/value divider,
+        # splitting the key and corrupting the value.
+        empty_cfg.newlines = '\n'
+        empty_cfg['a = b'] = 'val'
+        collector = io.BytesIO()
+        empty_cfg.write(collector)
+        assert collector.getvalue() == b'"a = b" = val\n'
+        # and the written form round-trips back to the original key/value
+        collector.seek(0)
+        assert dict(ConfigObj(collector)) == {'a = b': 'val'}
+
     def test_detecting_line_endings_from_existing_files(self):
         for expected_line_ending in ('\r\n', '\n'):
             with open('temp', 'w') as h:


### PR DESCRIPTION
## Summary

Fixes #273. A config **key** containing `=` is written **unquoted**, so on the next parse the first `=` is read as the key/value divider — silently splitting the key and corrupting the value:

```python
from configobj import ConfigObj
import io

co = ConfigObj()
co['a = b'] = 'val'
buf = io.BytesIO(); co.write(buf)          # writes:  a = b = val
buf.seek(0)
dict(ConfigObj(buf))                        # -> {'a': 'b = val'}   (corrupted)
```

The parser already *accepts* the correct quoted form (`"a = b" = val`) — only the writer fails to emit the quotes. The issue #273 example `"x <a='b'>"` is worse: it produces a file that raises `ParseError` on the next read.

## Cause

`_quote()` is shared by keys, values, list elements and section names. Its "no quoting needed" branch checks for leading/trailing whitespace-plus chars and `,`, but not `=`. That is correct for values, list elements and section names — `=` is legal unquoted there — but **not for a key**, where the first `=` on the line is the divider. `_write_line` quoted the key with no key-context flag.

## Fix

Add an `is_key` flag to `_quote()`. When it is set and the key contains `=`, force a quoted form via `_get_single_quote()` (which already picks `"`/`'` correctly, even when the key itself contains a quote char). `_write_line` passes `is_key=True` for the keyword; values, list elements and section markers are unchanged (`is_key=False`).

The guard sits ahead of both no-quote paths, so it also covers `list_values=False` (where the same corruption occurred).

## Verification

- New regression test `test_key_with_equals_is_quoted` asserts the written form (`"a = b" = val`) and that it round-trips back to `{'a = b': 'val'}`. It fails before the fix and passes after.
- Confirmed by hand: the minimal repro, the `list_values=False` path, issue #273's `"x <a='b'>"` example, and nested keys all round-trip; section names containing `=` stay unquoted (`[sec = x]`) and round-trip; normal keys and values are written exactly as before.
- Full suite: **80 passed** (was 79). `flake8 --max-line-length=132` introduces zero new warnings.

This pull request was prepared with the assistance of AI, under my direction and review.
