### PR TITLE
Drop artifacts from Python 2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # configobj documentation build configuration file, created by
 # sphinx-quickstart on Sat Feb  8 01:26:54 2014.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # setup.py
-# -*- coding: utf-8 -*-
 # pylint: disable=invalid-name
 
 """Install script for ConfigObj"""

--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -133,7 +133,7 @@ class UnknownType(Exception):
     pass
 
 
-class Builder(object):
+class Builder:
     
     def build(self, o):
         if m is None:
@@ -278,7 +278,7 @@ class UnreprError(ConfigObjError):
 
 
 
-class InterpolationEngine(object):
+class InterpolationEngine:
     """
     A helper class to help perform string interpolation.
 
@@ -2363,7 +2363,7 @@ class ConfigObj(Section):
         
 
 
-class SimpleVal(object):
+class SimpleVal:
     """
     A simple validator.
     Can be used to check that all members expected are present.

--- a/src/configobj/validate.py
+++ b/src/configobj/validate.py
@@ -428,7 +428,7 @@ class VdtValueTooLongError(VdtValueError):
         ValidateError.__init__(self, 'the value "%s" is too long.' % (value,))
 
 
-class Validator(object):
+class Validator:
     """
     Validator is an object that allows you to register a set of 'checks'.
     These checks take input and test that it conforms to the check.

--- a/src/configobj/validate.py
+++ b/src/configobj/validate.py
@@ -1357,11 +1357,6 @@ def _test(value, *args, **keywargs):
     >>> v.check('pass(default=list(1, 2, 3, 4))', None, True)
     ['1', '2', '3', '4']
     
-    Bug test for unicode arguments
-    >>> v = Validator()
-    >>> v.check('string(min=4)', 'test') == 'test'
-    True
-    
     >>> v = Validator()
     >>> v.get_default_value('string(min=4, default="1234")') == '1234'
     True

--- a/src/configobj/validate.py
+++ b/src/configobj/validate.py
@@ -277,24 +277,8 @@ def dottedQuadToNum(ip):
 
 def numToDottedQuad(num):
     """
-    Convert int or long int to dotted quad string
+    Convert int to dotted quad string
     
-    >>> numToDottedQuad(int(-1))
-    Traceback (most recent call last):
-    ValueError: Not a good numeric IP: -1
-    >>> numToDottedQuad(int(1))
-    '0.0.0.1'
-    >>> numToDottedQuad(int(16777218))
-    '1.0.0.2'
-    >>> numToDottedQuad(int(16908291))
-    '1.2.0.3'
-    >>> numToDottedQuad(int(16909060))
-    '1.2.3.4'
-    >>> numToDottedQuad(int(4294967295))
-    '255.255.255.255'
-    >>> numToDottedQuad(int(4294967296))
-    Traceback (most recent call last):
-    ValueError: Not a good numeric IP: 4294967296
     >>> numToDottedQuad(-1)
     Traceback (most recent call last):
     ValueError: Not a good numeric IP: -1
@@ -319,11 +303,11 @@ def numToDottedQuad(num):
     import struct
     
     # no need to intercept here, 4294967295L is fine
-    if num > int(4294967295) or num < 0:
+    if num > 4294967295 or num < 0:
         raise ValueError('Not a good numeric IP: %s' % num)
     try:
         return socket.inet_ntoa(
-            struct.pack('!L', int(num)))
+            struct.pack('!L', num))
     except (socket.error, struct.error, OverflowError):
         raise ValueError('Not a good numeric IP: %s' % num)
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import pytest
 
 from configobj import ConfigObj

--- a/src/tests/test_configobj.py
+++ b/src/tests/test_configobj.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-from __future__ import unicode_literals
 import os
 import re
 

--- a/src/tests/test_configobj.py
+++ b/src/tests/test_configobj.py
@@ -19,11 +19,11 @@ def cfg_lines(config_string_representation):
     """
     :param config_string_representation: string representation of a config
         file (typically a triple-quoted string)
-    :type config_string_representation: str or unicode
+    :type config_string_representation: str | bytes
     :return: a list of lines of that config. Whitespace on the left will be
         trimmed based on the indentation level to make it a bit saner to assert
         content of a particular line
-    :rtype: str or unicode
+    :rtype: str | bytes
     """
     lines = config_string_representation.splitlines()
 
@@ -59,11 +59,11 @@ def cfg_contents(request):
         """
         :param config_string_representation: string representation of a config
             file (typically a triple-quoted string)
-        :type config_string_representation: str or unicode
+        :type config_string_representation: str | bytes
         :return: a list of lines of that config. Whitespace on the left will be
             trimmed based on the indentation level to make it a bit saner to assert
             content of a particular line
-        :rtype: basestring
+        :rtype: str
         """
 
         lines = cfg_lines(config_string_representation)

--- a/src/tests/test_configobj.py
+++ b/src/tests/test_configobj.py
@@ -171,7 +171,7 @@ def test_interoplation_repr():
     repr(c)
 
 
-class TestEncoding(object):
+class TestEncoding:
     @pytest.fixture
     def ant_cfg(self):
         return """
@@ -512,7 +512,7 @@ def test_unicode_handling():
     assert uc2.newlines == '\r'
 
 
-class TestWritingConfigs(object):
+class TestWritingConfigs:
     def test_validate(self, val):
         spec = [
             '# Initial Comment',
@@ -565,7 +565,7 @@ class TestWritingConfigs(object):
         assert cfg.write() == ['', 'key1 = ', 'key2 = # a comment']
 
 
-class TestUnrepr(object):
+class TestUnrepr:
     def test_in_reading(self):
         config_to_be_unreprd = cfg_lines("""
             key1 = (1, 2, 3)    # comment
@@ -613,7 +613,7 @@ class TestUnrepr(object):
         }
 
 
-class TestValueErrors(object):
+class TestValueErrors:
     def test_bool(self, empty_cfg):
         empty_cfg['a'] = 'fish'
         with pytest.raises(ValueError) as excinfo:
@@ -674,7 +674,7 @@ def test_error_types():
         raise co.ReloadError()
 
 
-class TestSectionBehavior(object):
+class TestSectionBehavior:
     def test_dictionary_representation(self, a):
 
         n = a.dict()
@@ -772,7 +772,7 @@ def test_reset_a_configobj():
     assert repr(cfg) == 'ConfigObj({})'
 
 
-class TestReloading(object):
+class TestReloading:
     @pytest.fixture
     def reloadable_cfg_content(self):
         content = '''
@@ -847,7 +847,7 @@ class TestReloading(object):
         assert cfg.validate(Validator())
 
 
-class TestDuplicates(object):
+class TestDuplicates:
     def test_duplicate_section(self):
         cfg = '''
         [hello]
@@ -877,7 +877,7 @@ class TestDuplicates(object):
         assert str(excinfo.value) == 'Duplicate keyword name at line 7.'
 
 
-class TestInterpolation(object):
+class TestInterpolation:
     """
     tests various interpolation behaviors using config par
     """
@@ -974,7 +974,7 @@ class TestInterpolation(object):
                 '$foo + 123 + 123 + $foo + 123 + $foo')
 
 
-class TestQuotes(object):
+class TestQuotes:
     """
     tests what happens whn dealing with quotes
     """
@@ -1018,7 +1018,7 @@ def test_handle_stringify_off():
     assert str(excinfo.value) == 'Value is not a string "1".'
 
 
-class TestValues(object):
+class TestValues:
     """
     Tests specifics about behaviors with types of values
     """
@@ -1105,7 +1105,7 @@ def test_creating_with_a_dictionary():
     assert dictionary_cfg_content is not cfg.dict()
 
 
-class TestComments(object):
+class TestComments:
     @pytest.fixture
     def comment_filled_cfg(self, cfg_contents):
         return cfg_contents("""
@@ -1217,7 +1217,7 @@ def test_interpolation_using_default_sections():
     assert c.write() == ['a = %(a)s', '[DEFAULT]', 'a = fish']
     
 
-class TestIndentation(object):
+class TestIndentation:
     @pytest.fixture
     def max_tabbed_cfg(self):
         return ['[sect]', '    [[sect]]', '        foo = bar']
@@ -1248,7 +1248,7 @@ class TestIndentation(object):
         assert ConfigObj(one_tab, indent_type='    ').write() == max_tabbed_cfg
 
 
-class TestEdgeCasesWhenWritingOut(object):
+class TestEdgeCasesWhenWritingOut:
     def test_newline_terminated(self, empty_cfg):
         empty_cfg.newlines = '\n'
         empty_cfg['a'] = 'b'

--- a/src/tests/test_validate.py
+++ b/src/tests/test_validate.py
@@ -5,7 +5,7 @@ import pytest
 from configobj.validate import VdtValueTooSmallError
 
 
-class TestImporting(object):
+class TestImporting:
     def test_top_level(self, val):
         import validate
         assert val.__class__ is validate.Validator
@@ -19,7 +19,7 @@ class TestImporting(object):
         assert val.__class__ is configobj.validate.Validator
 
 
-class TestBasic(object):
+class TestBasic:
     def test_values_too_small(self, val):
         config = '''
         test1=40

--- a/src/tests/test_validate.py
+++ b/src/tests/test_validate.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 from configobj import ConfigObj
 import pytest
 from configobj.validate import VdtValueTooSmallError


### PR DESCRIPTION
Hello. Fixed some leftover artifacts from Python 2 (previous work - 861383c):

- 3cc26d1bbe5af94c4c30053a4b69ccd4e5f13b92 - Python 3 assumes utf-8 by default, so not needed. `unicode_literals` is also artifact from Python 2, that was allowing `"hello"` to be interpreted as `unicode` instead of `str`, useless now.

- a1b2e7fcc79f4a62327b72372f00bcbc4105f46b - `object` base is assumed in Python 3 by default

- 77ddd3d3a0addc19992e54063544430311a49ac9 - test seems unnecessary now - previously it was testing `unicode` and the next one was testing `str`, so since there's no `unicode` and it's testing the same thing in both cases, so it can be removed. Besides that just updated doc-strings not to mention `unicode`, for `make_file_with_contents_and_return_name` return type is actually `str`, not `basestring`, fixed.

- cbdd8c78b21ebc19c28436c7b1dadfc3f1ed7f7f - test that's using `int`  was originally using `long`. But since Python 3 doesn't have `long` anymore, this test is redundant and it's testing exactly the same thing as the test below it.

@jelmer can you please take a look?