### PR TITLE
Drop dead `Builder` class and `_builder` instance

### DIFF
--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -133,64 +133,6 @@ class UnknownType(Exception):
     pass
 
 
-class Builder:
-    
-    def build(self, o):
-        if m is None:
-            raise UnknownType(o.__class__.__name__)
-        return m(o)
-    
-    def build_List(self, o):
-        return list(map(self.build, o.getChildren()))
-    
-    def build_Const(self, o):
-        return o.value
-    
-    def build_Dict(self, o):
-        d = {}
-        i = iter(map(self.build, o.getChildren()))
-        for el in i:
-            d[el] = next(i)
-        return d
-    
-    def build_Tuple(self, o):
-        return tuple(self.build_List(o))
-    
-    def build_Name(self, o):
-        if o.name == 'None':
-            return None
-        if o.name == 'True':
-            return True
-        if o.name == 'False':
-            return False
-        
-        # An undefined Name
-        raise UnknownType('Undefined Name')
-    
-    def build_Add(self, o):
-        real, imag = list(map(self.build_Const, o.getChildren()))
-        try:
-            real = float(real)
-        except TypeError:
-            raise UnknownType('Add')
-        if not isinstance(imag, complex) or imag.real != 0.0:
-            raise UnknownType('Add')
-        return real+imag
-    
-    def build_Getattr(self, o):
-        parent = self.build(o.expr)
-        return getattr(parent, o.attrname)
-    
-    def build_UnarySub(self, o):
-        return -self.build_Const(o.getChildren()[0])
-    
-    def build_UnaryAdd(self, o):
-        return self.build_Const(o.getChildren()[0])
-
-
-_builder = Builder()
-
-
 def unrepr(s):
     if not s:
         return s


### PR DESCRIPTION
Hi! Class `Builder` was introduced long time ago in 6ee360d and was used to convert AST to Python objects:

<img width="547" height="255" alt="image" src="https://github.com/user-attachments/assets/c08f4583-d7b6-45b0-899b-64991e666dd2" />

Then it was replaced in 4e9ee6a e37ccb5 with `ast.literal_eval(s)` and since then it was a dead code. Removing it in this PR.


<img width="546" height="284" alt="image" src="https://github.com/user-attachments/assets/5615bb60-58ed-4486-93dc-3cea2b458937" />

<img width="546" height="284" alt="image" src="https://github.com/user-attachments/assets/66b5c493-27c5-4a1b-aad8-46c4e1c16943" />

@jelmer 
