### PR TITLE
Raise InterpolationError when interpolating a list-valued option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+Unreleased
+""""""""""
+
+* raise ``InterpolationError`` instead of leaking a raw ``TypeError`` when a
+  value interpolates a reference to an option whose value is a list
+
 Release 5.0.9
 """""""""""""
 

--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -270,6 +270,13 @@ class InterpolationEngine:
                     replacement = v
                 else:
                     # Further interpolation may be needed to obtain final value
+                    if not isinstance(v, str):
+                        # Only strings can be substituted into a value; a list
+                        # (or any other non-string) has no meaningful textual
+                        # form to interpolate.
+                        raise InterpolationError(
+                            'cannot interpolate non-string value of '
+                            'option "%s".' % k)
                     replacement = recursive_interpolate(k, v, s, backtrail)
                 # Replace the matched string with its final value
                 start, end = match.span()

--- a/src/tests/test_configobj.py
+++ b/src/tests/test_configobj.py
@@ -957,6 +957,19 @@ class TestInterpolation:
         assert (str(excinfo.value) ==
                 'interpolation loop detected in value "e".')
 
+    def test_interpolation_of_list_value_raises(self):
+        # A reference to a key whose value is a list has no meaningful
+        # string form to substitute, so a clear InterpolationError should
+        # be raised rather than a raw TypeError leaking out.
+        cfg = ConfigObj(['foo = %(bar)s', 'bar = a, b, c'])
+        with pytest.raises(co.InterpolationError):
+            cfg['foo']
+
+        tmpl = ConfigObj(['foo = ${bar}', 'bar = a, b, c'],
+                         interpolation='template')
+        with pytest.raises(co.InterpolationError):
+            tmpl['foo']
+
     def test_template_interpolation(self, template_cfg):
         test_sec = template_cfg['section']
         assert test_sec['templatebare'] == 'value1/foo'


### PR DESCRIPTION
Referencing an option whose value is a list leaks a raw `TypeError` instead of configobj's own `InterpolationError`:

```python
from configobj import ConfigObj
ConfigObj(["foo = %(bar)s", "bar = a, b, c"])["foo"]
# TypeError: expected string or bytes-like object, got 'list'
```

`bar` parses as a list, and the interpolation engine then runs its regex against the list value and indexes into it. A list has no meaningful string form to substitute, so I raise `InterpolationError` with a clear message like the other interpolation failures do. Added a test covering both the `%(...)s` and template (`${...}`) syntaxes.
