### PR TITLE
Reject NaN against a declared float bound

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Unreleased
 
 * raise ``InterpolationError`` instead of leaking a raw ``TypeError`` when a
   value interpolates a reference to an option whose value is a list
+* reject ``NaN`` against a declared ``float`` bound; every comparison against
+  ``NaN`` is False, so it previously satisfied neither the ``min`` nor the
+  ``max`` check and was accepted as valid
 
 Release 5.0.9
 """""""""""""

--- a/src/configobj/validate.py
+++ b/src/configobj/validate.py
@@ -840,9 +840,12 @@ def is_float(value, min=None, max=None):
             value = float(value)
         except ValueError:
             raise VdtTypeError(value)
-    if (min_val is not None) and (value < min_val):
+    # Phrased as "must satisfy the bound" rather than "must not violate it",
+    # so that a NaN -- for which every comparison is False -- fails a declared
+    # bound instead of slipping past both checks.
+    if (min_val is not None) and not (value >= min_val):
         raise VdtValueTooSmallError(value)
-    if (max_val is not None) and (value > max_val):
+    if (max_val is not None) and not (value <= max_val):
         raise VdtValueTooBigError(value)
     return value
 

--- a/src/tests/test_validate.py
+++ b/src/tests/test_validate.py
@@ -1,6 +1,8 @@
+import math
+
 from configobj import ConfigObj
 import pytest
-from configobj.validate import VdtValueTooSmallError
+from configobj.validate import VdtValueTooBigError, VdtValueTooSmallError
 
 
 class TestImporting:
@@ -173,3 +175,23 @@ class TestBasic:
                     'test3': 3,
                     'test4': 6.0
         }}}
+
+
+class TestFloatBounds:
+    """A declared bound must reject NaN, for which every comparison is False."""
+
+    def test_nan_fails_min(self, val):
+        with pytest.raises(VdtValueTooSmallError):
+            val.check('float(0, 10)', 'nan')
+
+    def test_nan_fails_max_only(self, val):
+        with pytest.raises(VdtValueTooBigError):
+            val.check('float(max=10)', 'nan')
+
+    def test_bounded_floats_still_pass(self, val):
+        assert val.check('float(0, 10)', '5.0') == 5.0
+        assert val.check('float(0, 10)', '0') == 0.0
+        assert val.check('float(0, 10)', '10') == 10.0
+
+    def test_unbounded_float_is_unchanged(self, val):
+        assert math.isnan(val.check('float', 'nan'))


### PR DESCRIPTION
`is_float` bounds-checks with `value < min_val` / `value > max_val` (`src/configobj/validate.py:843-846`). Every comparison against NaN is False, so a NaN violates neither test and is returned as valid, while `inf` and `-inf` are correctly rejected by those same bounds.

The fix phrases each check as *must satisfy the bound* rather than *must not violate it*, so NaN fails. An unbounded `float` still accepts NaN, pinned by a test. `is_integer` is unaffected, since it converts through `int()` before any bound is compared.

One choice worth your word: with a bound declared, NaN now raises `VdtValueTooSmallError`, which follows from the ordering rather than from a claim that NaN is "too small". Say so and I'll make it `VdtTypeError`.

`python -m pytest src/tests/ -q` on `5.0.x`: 76 passed clean, 2 failed with the new tests added alone, 80 passed with this PR.

Based on `5.0.x` rather than `release`, since #275, #276, #278 all merged there.

AI disclosure: found and drafted with Claude Code (Claude Opus 5, `claude-opus-5`). Reviewed before submission.
